### PR TITLE
Change required versions for psr/log composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3,<8.3",
         "ext-curl": "*",
         "ext-json": "*",
-        "psr/log": "^1.0.0"
+        "psr/log": "^1.0.0 | ^2.0 | ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35",


### PR DESCRIPTION
Promenjena je neophodna verzija `psr/log` composer paketa kako bih omogucio upgrade symfony frameworka. 