### PR TITLE
Fix:  Use of `self` in callables is deprecated

### DIFF
--- a/lib/PayPal/Common/ReflectionUtil.php
+++ b/lib/PayPal/Common/ReflectionUtil.php
@@ -150,6 +150,6 @@ class ReflectionUtil
     {
         return method_exists($class, "get" . ucfirst($propertyName)) ?
             "get" . ucfirst($propertyName) :
-            "get" . preg_replace_callback("/([_\-\s]?([a-z0-9]+))/", "self::replace_callback", $propertyName);
+            "get" . preg_replace_callback("/([_\-\s]?([a-z0-9]+))/", [self::class, 'replace_callback'], $propertyName);
     }
 }


### PR DESCRIPTION
U logovima se pojavljuje za cronjob accounting fetchPaypalTransactions

<h4>A PHP Error was encountered</h4>

<p>Severity: 8192</p>
<p>Message: Use of "self" in callables is deprecated</p>
<p>Filename: Common/ReflectionUtil.php</p>
<p>Line Number: 153</p>

@ilija-petkovic dodao sam tebe za review jer vidim da si zadnji radio na repositoryju ali ako neko drugi održava zameni reviewer-a :)