### PR TITLE
PHP Upgrade 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
         }
     ],
     "require": {
-        "php": ">=5.3,<8.3",
+        "php": ">=5.3,<8.5",
         "ext-curl": "*",
         "ext-json": "*",
         "psr/log": "^1.0.0 | ^2.0 | ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35",
-        "rector/rector": "^0.15.23"
+        "rector/rector": "^1.0"
     },
     "autoload": {
         "psr-0": {

--- a/lib/PayPal/Auth/OAuthTokenCredential.php
+++ b/lib/PayPal/Auth/OAuthTokenCredential.php
@@ -282,7 +282,7 @@ class OAuthTokenCredential extends PayPalResourceModel
         if ($response == null || !isset($response["access_token"]) || !isset($response["expires_in"])) {
             $this->accessToken = null;
             $this->tokenExpiresIn = null;
-            PayPalLoggingManager::getInstance(__CLASS__)->warning("Could not generate new Access token. Invalid response from server: ");
+            PayPalLoggingManager::getInstance(self::class)->warning("Could not generate new Access token. Invalid response from server: ");
             throw new PayPalConnectionException(null, "Could not generate new Access token. Invalid response from server: ");
         } else {
             $this->accessToken = $response["access_token"];

--- a/lib/PayPal/Common/PayPalModel.php
+++ b/lib/PayPal/Common/PayPalModel.php
@@ -3,13 +3,14 @@
 namespace PayPal\Common;
 
 use PayPal\Validation\JsonValidator;
+use Stringable;
 
 /**
  * Generic Model class that all API domain classes extend
  * Stores all member data in a Hashmap that enables easy
  * JSON encoding/decoding
  */
-class PayPalModel
+class PayPalModel implements Stringable
 {
 
     private $_propMap = array();
@@ -302,7 +303,7 @@ class PayPalModel
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->toJSON(128);
     }

--- a/lib/PayPal/Common/ReflectionUtil.php
+++ b/lib/PayPal/Common/ReflectionUtil.php
@@ -148,8 +148,12 @@ class ReflectionUtil
      */
     public static function getter($class, $propertyName)
     {
-        return method_exists($class, "get" . ucfirst($propertyName)) ?
-            "get" . ucfirst($propertyName) :
-            "get" . preg_replace_callback("/([_\-\s]?([a-z0-9]+))/", [self::class, 'replace_callback'], $propertyName);
+        return method_exists($class, "get" . ucfirst($propertyName))
+            ? "get" . ucfirst($propertyName)
+            : "get" . preg_replace_callback(
+                "/([_\-\s]?([a-z0-9]+))/",
+                [ReflectionUtil::class, 'replace_callback'],
+                $propertyName,
+            );
     }
 }

--- a/lib/PayPal/Core/PayPalConfigManager.php
+++ b/lib/PayPal/Core/PayPalConfigManager.php
@@ -37,7 +37,7 @@ class PayPalConfigManager
             $configFile = constant('PP_CONFIG_PATH') . '/sdk_config.ini';
         } else {
             $configFile = implode(DIRECTORY_SEPARATOR,
-                array(dirname(__FILE__), "..", "config", "sdk_config.ini"));
+                array(__DIR__, "..", "config", "sdk_config.ini"));
         }
         if (file_exists($configFile)) {
             $this->addConfigFromIni($configFile);

--- a/lib/PayPal/Core/PayPalHttpConnection.php
+++ b/lib/PayPal/Core/PayPalHttpConnection.php
@@ -48,7 +48,7 @@ class PayPalHttpConnection
             throw new PayPalConfigurationException("Curl module is not available on this system");
         }
         $this->httpConfig = $httpConfig;
-        $this->logger = PayPalLoggingManager::getInstance(__CLASS__);
+        $this->logger = PayPalLoggingManager::getInstance(self::class);
     }
 
     /**
@@ -88,7 +88,7 @@ class PayPalHttpConnection
             return strlen($data);
         }
         
-        list($key, $value) = explode(":", $trimmedData, 2);
+        [$key, $value] = explode(":", $trimmedData, 2);
 
         $key = trim($key);
         $value = trim($value);
@@ -175,7 +175,7 @@ class PayPalHttpConnection
         //Retry if Certificate Exception
         if (curl_errno($ch) == 60) {
             $this->logger->info("Invalid or no certificate authority found - Retrying using bundled CA certs file");
-            curl_setopt($ch, CURLOPT_CAINFO, dirname(__FILE__) . '/cacert.pem');
+            curl_setopt($ch, CURLOPT_CAINFO, __DIR__ . '/cacert.pem');
             $result = curl_exec($ch);
             //Retrieve Response Status
             $httpStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);

--- a/lib/PayPal/Core/PayPalLoggingManager.php
+++ b/lib/PayPal/Core/PayPalLoggingManager.php
@@ -37,7 +37,7 @@ class PayPalLoggingManager
      * @param string $loggerName
      * @return $this
      */
-    public static function getInstance($loggerName = __CLASS__)
+    public static function getInstance($loggerName = self::class)
     {
         if (array_key_exists($loggerName, PayPalLoggingManager::$instances)) {
             return PayPalLoggingManager::$instances[$loggerName];

--- a/lib/PayPal/Transport/PayPalRestCall.php
+++ b/lib/PayPal/Transport/PayPalRestCall.php
@@ -38,7 +38,7 @@ class PayPalRestCall
     public function __construct(ApiContext $apiContext)
     {
         $this->apiContext = $apiContext;
-        $this->logger = PayPalLoggingManager::getInstance(__CLASS__);
+        $this->logger = PayPalLoggingManager::getInstance(self::class);
     }
 
     /**

--- a/rector.php
+++ b/rector.php
@@ -7,13 +7,11 @@ use Rector\Php52\Rector\Property\VarToPublicPropertyRector;
 use Rector\Php53\Rector\Ternary\TernaryToElvisRector;
 use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
-use Rector\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector;
 use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector;
 use Rector\Php70\Rector\Ternary\TernaryToNullCoalescingRector;
 use Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector;
 use Rector\Php71\Rector\ClassConst\PublicConstantVisibilityRector;
-use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Php71\Rector\TryCatch\MultiExceptionCatchRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
@@ -21,14 +19,12 @@ use Rector\Php73\Rector\FuncCall\SetCookieRector;
 use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
 use Rector\Php74\Rector\Assign\NullCoalescingOperatorRector;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
-use Rector\Php74\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
 use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
 use Rector\Php74\Rector\Ternary\ParenthesizeNestedTernaryRector;
 use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php80\Rector\FuncCall\ClassOnObjectRector;
 use Rector\Php80\Rector\FunctionLike\MixedTypeRector;
-use Rector\Php80\Rector\FunctionLike\UnionTypesRector;
 use Rector\Php80\Rector\Identical\StrEndsWithRector;
 use Rector\Php80\Rector\Identical\StrStartsWithRector;
 use Rector\Php80\Rector\NotIdentical\StrContainsRector;
@@ -45,7 +41,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // define sets of rules
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_80
+        LevelSetList::UP_TO_PHP_84,
     ]);
 
     $rectorConfig->skip([
@@ -54,9 +50,6 @@ return static function (RectorConfig $rectorConfig): void {
         MultiExceptionCatchRector::class,
         ChangeSwitchToMatchRector::class,
         LongArrayToShortArrayRector::class,
-        ArraySpreadInsteadOfArrayMergeRector::class,
-        AddDefaultValueForUndefinedVariableRector::class,
-        CountOnNullRector::class,
         JsonThrowOnErrorRector::class,
         ClosureToArrowFunctionRector::class,
         StrContainsRector::class,
@@ -65,7 +58,6 @@ return static function (RectorConfig $rectorConfig): void {
         PublicConstantVisibilityRector::class,
         TypedPropertyFromAssignsRector::class,
         RandomFunctionRector::class,
-        UnionTypesRector::class,
         MixedTypeRector::class,
         TernaryToNullCoalescingRector::class,
         TernaryToElvisRector::class,


### PR DESCRIPTION
## Reason for this change (Why?)

We're upgrading from PHP 8.2 to PHP 8.4.

---

## Solution (How?)

- Updated `composer.json` to allow PHP `<8.5`
- Upgraded Rector to `^1.0` to support PHP 8.4 transformations
- Changed Rector config from `LevelSetList::UP_TO_PHP_80` to `LevelSetList::UP_TO_PHP_84`
- Cleaned up unused or incompatible Rector rules
- Replaced `__CLASS__` with `self::class`
- Applied modern PHP features:
  - Implemented `Stringable` interface
  - Used array destructuring (`[$key, $value]`)
  - Replaced `dirname(__FILE__)` with `__DIR__`

## Impact of this change

- [ ] **Breaking Change** - A change that is not backward-compatible.
- [ ] New Feature - A change that adds functionality.
- [x] Tweak - A change that tweaks existing features.
- [ ] Bugfix - A change that resolves an issue.

